### PR TITLE
Add support for imx8qxp u-boot

### DIFF
--- a/pkgs/misc/arm-trusted-firmware/default.nix
+++ b/pkgs/misc/arm-trusted-firmware/default.nix
@@ -126,4 +126,16 @@ in {
     extraMeta.platforms = ["aarch64-linux"];
     filesToInstall = [ "build/${platform}/release/bl31.bin"];
   };
+
+  armTrustedFirmwareIMX8QXP = buildArmTrustedFirmware rec {
+    src = fetchGit {
+      url = "https://source.codeaurora.org/external/imx/imx-atf";
+      ref = "lf_v2.6";
+    };
+    platform = "imx8qx";
+    enableParallelBuilding = true;
+    extraMakeFlags = [ "bl31" ];
+    extraMeta.platforms = [ "aarch64-linux" ];
+    filesToInstall = [ "build/${platform}/release/bl31.bin" ];
+  };
 }

--- a/pkgs/misc/imx-firmware/default.nix
+++ b/pkgs/misc/imx-firmware/default.nix
@@ -1,0 +1,60 @@
+{ lib, stdenv, fetchurl}:
+
+let
+
+  imxurl = "https://www.nxp.com/lgfiles/NMG/MAD/YOCTO";
+
+  fwHdmiVersion = "8.16";
+  fwScVersion = "1.13.0";
+  fwSecoVersion = "3.8.6";
+
+  firmwareHdmi = fetchurl rec {
+    url = "${imxurl}/firmware-imx-${fwHdmiVersion}.bin";
+    sha256 = "Bun+uxE5z7zvxnlRwI0vjowKFqY4CgKyiGjbZuilER0=";
+    executable = true;
+  };
+
+  firmwareSc = fetchurl rec {
+    url = "${imxurl}/imx-sc-firmware-${fwScVersion}.bin";
+    sha256 = "YUaBIVCeOOTvifhiEIbKgyGsLZYufv5rs2isdSrw4dc=";
+    executable = true;
+  };
+
+  firmwareSeco = fetchurl rec {
+    url = "${imxurl}/imx-seco-${fwSecoVersion}.bin";
+    sha256 = "eoG19xn283fsP2jP49hD4dIBRwEQqFQ9k3yVWOM8uKQ=";
+    executable = true;
+  };
+
+in
+
+stdenv.mkDerivation rec {
+  pname = "imx-firmware";
+  version = "5.15.X_1.0.0-Yocto";
+
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  sourceRoot = ".";
+
+  unpackPhase = ''
+    ${firmwareHdmi} --auto-accept --force
+    ${firmwareSc} --auto-accept --force
+    ${firmwareSeco} --auto-accept --force
+  '';
+
+  filesToInstall = [
+    "firmware-imx-${fwHdmiVersion}/firmware/hdmi/cadence/dpfw.bin"
+    "firmware-imx-${fwHdmiVersion}/firmware/hdmi/cadence/hdmi?xfw.bin"
+    "imx-sc-firmware-${fwScVersion}/mx8qm-mek-scfw-tcm.bin"
+    "imx-seco-${fwSecoVersion}/firmware/seco/mx8qmb0-ahab-container.img"
+    "imx-sc-firmware-${fwScVersion}/mx8qx-mek-scfw-tcm.bin"
+    "imx-seco-${fwSecoVersion}/firmware/seco/mx8qxc0-ahab-container.img"
+  ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp ${lib.concatStringsSep " " filesToInstall} $out
+  '';
+}

--- a/pkgs/misc/imx-mkimage/default.nix
+++ b/pkgs/misc/imx-mkimage/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchgit, git, glibc, gcc }:
+
+stdenv.mkDerivation rec {
+  pname = "imx-mkimage";
+  version = "lf-5.15.32_2.0.0";
+
+  src = fetchgit {
+    url = "https://source.codeaurora.org/external/imx/imx-mkimage.git";
+    rev = "a8bb8edb45492ac70b33734122a57aa8e38a20bd";
+    sha256 = "sha256-jdmAvmjoWZ1wtpBNX4cF0f2k7lIGjkmoj+SSLGbNq9M=";
+  };
+
+  patches = [
+    ./fix-gcc-for-nix.patch
+  ];
+
+  nativeBuildInputs = [
+    git
+  ];
+
+  buildInputs = [
+    gcc
+    glibc.static
+  ];
+
+  makeFlags = [
+    "bin"
+  ];
+
+  installPhase = ''
+    install -m 0755 mkimage_imx8 $out
+  '';
+}

--- a/pkgs/misc/imx-mkimage/fix-gcc-for-nix.patch
+++ b/pkgs/misc/imx-mkimage/fix-gcc-for-nix.patch
@@ -1,0 +1,12 @@
+diff --git a/Makefile b/Makefile
+index 1c0b039..d379f08 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,6 +1,6 @@
+ 
+ MKIMG = $(PWD)/mkimage_imx8
+-CC = gcc
++CC ?= gcc
+ CFLAGS ?= -g -O2 -Wall -std=c99 -static
+ INCLUDE += $(CURR_DIR)/src
+ 

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -16,7 +16,10 @@
 , armTrustedFirmwareRK3328
 , armTrustedFirmwareRK3399
 , armTrustedFirmwareS905
+, armTrustedFirmwareIMX8QXP
 , buildPackages
+, imx-firmware
+, imx-mkimage
 }:
 
 let
@@ -514,5 +517,31 @@ in {
     extraMeta.platforms = ["aarch64-linux"];
     BL31 = "${armTrustedFirmwareRK3399}/bl31.elf";
     filesToInstall = [ "u-boot.itb" "idbloader.img"];
+  };
+
+  ubootIMX8QXP = buildUBoot {
+    version = "2022.04";
+    src = fetchGit {
+      url = "https://github.com/tiiuae/uboot-imx8.git";
+      ref = "lf_v2022.04-uefi";
+    };
+    BL31 = "${armTrustedFirmwareIMX8QXP}/bl31.bin";
+    enableParallelBuilding = true;
+    defconfig = "imx8qxp_mek_defconfig";
+    extraMeta.platforms = ["aarch64-linux"];
+    filesToInstall = [ "flash.bin" ];
+    preBuildPhases = [ "copyBinaries" ];
+    copyBinaries = ''
+      install -m 0644 ${armTrustedFirmwareIMX8QXP}/bl31.bin ./bl31.bin
+      install -m 0644 ${imx-firmware}/mx8qxc0-ahab-container.img ./ahab-container.img
+      install -m 0644 ${imx-firmware}/mx8qx-mek-scfw-tcm.bin ./mx8qx-mek-scfw-tcm.bin
+    '';
+    postBuild = ''
+      ${imx-mkimage} -commit > head.hash
+      cat u-boot.bin head.hash > u-boot-hash.bin
+      cp bl31.bin u-boot-atf.bin
+      dd if=u-boot-hash.bin of=u-boot-atf.bin bs=1K seek=128
+      ${imx-mkimage} -soc QX -rev B0 -append ahab-container.img -c -scfw mx8qx-mek-scfw-tcm.bin -ap u-boot-atf.bin a35 0x80000000 -out flash.bin
+    '';
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22825,7 +22825,12 @@ with pkgs;
     armTrustedFirmwareRK3328
     armTrustedFirmwareRK3399
     armTrustedFirmwareS905
+    armTrustedFirmwareIMX8QXP
     ;
+
+  imx-firmware = callPackage ../misc/imx-firmware { };
+
+  imx-mkimage = callPackage ../misc/imx-mkimage { };
 
   microcodeAmd = callPackage ../os-specific/linux/microcode/amd.nix { };
 
@@ -23932,6 +23937,7 @@ with pkgs;
     ubootSopine
     ubootUtilite
     ubootWandboard
+    ubootIMX8QXP
     ;
 
   # Upstream Barebox:


### PR DESCRIPTION
Signed-off-by: Yuri Nesterov <yuri.nesterov@gmail.com>

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
