### PR TITLE
Add support for imx8qm u-boot

### DIFF
--- a/pkgs/misc/arm-trusted-firmware/default.nix
+++ b/pkgs/misc/arm-trusted-firmware/default.nix
@@ -138,4 +138,16 @@ in {
     extraMeta.platforms = [ "aarch64-linux" ];
     filesToInstall = [ "build/${platform}/release/bl31.bin" ];
   };
+
+  armTrustedFirmwareIMX8QM = buildArmTrustedFirmware rec {
+    src = fetchGit {
+      url = "https://source.codeaurora.org/external/imx/imx-atf";
+      ref = "lf_v2.6";
+    };
+    platform = "imx8qm";
+    enableParallelBuilding = true;
+    extraMakeFlags = [ "bl31" ];
+    extraMeta.platforms = [ "aarch64-linux" ];
+    filesToInstall = [ "build/${platform}/release/bl31.bin" ];
+  };
 }

--- a/pkgs/misc/uboot/0001-imx8qm-uefi.patch
+++ b/pkgs/misc/uboot/0001-imx8qm-uefi.patch
@@ -1,0 +1,69 @@
+diff --git a/configs/imx8qm_mek_defconfig b/configs/imx8qm_mek_defconfig
+index 29e9d796a6..bb8b6a8d1c 100644
+--- a/configs/imx8qm_mek_defconfig
++++ b/configs/imx8qm_mek_defconfig
+@@ -31,7 +31,7 @@ CONFIG_PANIC_HANG=y
+ CONFIG_OF_SYSTEM_SETUP=y
+ CONFIG_BOOTDELAY=3
+ CONFIG_USE_BOOTCOMMAND=y
+-CONFIG_BOOTCOMMAND="mmc dev ${mmcdev}; if mmc rescan; then if run loadbootscript; then run bootscript; else if test ${sec_boot} = yes; then if run loadcntr; then run mmcboot; else run netboot; fi; else if run loadimage; then run mmcboot; else run netboot; fi; fi; fi; else booti ${loadaddr} - ${fdt_addr}; fi"
++CONFIG_BOOTCOMMAND="run distro_bootcmd; mmc dev ${mmcdev}; if mmc rescan; then if run loadbootscript; then run bootscript; else if test ${sec_boot} = yes; then if run loadcntr; then run mmcboot; else run netboot; fi; else if run loadimage; then run mmcboot; else run netboot; fi; fi; fi; else booti ${loadaddr} - ${fdt_addr}; fi"
+ CONFIG_LOG=y
+ CONFIG_BOARD_EARLY_INIT_F=y
+ CONFIG_SPL_BOARD_INIT=y
+@@ -196,3 +196,10 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+ CONFIG_SPLASH_SCREEN=y
+ CONFIG_SPLASH_SCREEN_ALIGN=y
+ CONFIG_CMD_BMP=y
++CONFIG_DISTRO_DEFAULTS=y
++CONFIG_CMD_BOOTEFI_SELFTEST=y
++CONFIG_CMD_BOOTEFI=y
++CONFIG_EFI_LOADER=y
++CONFIG_BLK=y
++CONFIG_PARTITIONS=y
++CONFIG_DM_DEVICE_REMOVE=n
+diff --git a/include/configs/imx8qm_mek.h b/include/configs/imx8qm_mek.h
+index ed5c179fc7..ab5b58ec32 100644
+--- a/include/configs/imx8qm_mek.h
++++ b/include/configs/imx8qm_mek.h
+@@ -138,6 +138,22 @@
+ 	"m4boot_0=run loadm4image_0; dcache flush; bootaux ${loadaddr} 0\0" \
+ 	"m4boot_1=run loadm4image_1; dcache flush; bootaux ${loadaddr} 1\0" \
+ 
++#ifdef CONFIG_DISTRO_DEFAULTS
++#define BOOT_TARGET_DEVICES(func) \
++       func(MMC, mmc, 1) \
++       func(MMC, mmc, 0)
++
++#include <config_distro_bootcmd.h>
++#else
++#define BOOTENV
++#endif
++
++#define MEM_LAYOUT_ENV_SETTINGS \
++       "fdt_addr_r=0x83000000\0" \
++       "kernel_addr_r=0x80200000\0" \
++       "ramdisk_addr_r=0x83100000\0" \
++       "scriptaddr=0x83200000\0" \
++
+ #ifdef CONFIG_NAND_BOOT
+ #define MFG_NAND_PARTITION "mtdparts=gpmi-nand:128m(boot),32m(kernel),16m(dtb),8m(misc),-(rootfs) "
+ #else
+@@ -166,6 +182,8 @@
+ /* Initial environment variables */
+ #define CONFIG_EXTRA_ENV_SETTINGS		\
+ 	CONFIG_MFG_ENV_SETTINGS \
++	MEM_LAYOUT_ENV_SETTINGS \
++	BOOTENV \
+ 	M4_BOOT_ENV \
+ 	XEN_BOOT_ENV \
+ 	JAILHOUSE_ENV\
+@@ -179,7 +197,7 @@
+ 	"cntr_addr=0x98000000\0"			\
+ 	"cntr_file=os_cntr_signed.bin\0" \
+ 	"boot_fdt=try\0" \
+-	FDT_FILE \
++	"fdtfile=imx8qm-mek-hdmi.dtb\0" \
+ 	"mmcdev="__stringify(CONFIG_SYS_MMC_ENV_DEV)"\0" \
+ 	"mmcpart=1\0" \
+ 	"mmcroot=" CONFIG_MMCROOT " rootwait rw\0" \

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -17,6 +17,7 @@
 , armTrustedFirmwareRK3399
 , armTrustedFirmwareS905
 , armTrustedFirmwareIMX8QXP
+, armTrustedFirmwareIMX8QM
 , buildPackages
 , imx-firmware
 , imx-mkimage
@@ -542,6 +543,35 @@ in {
       cp bl31.bin u-boot-atf.bin
       dd if=u-boot-hash.bin of=u-boot-atf.bin bs=1K seek=128
       ${buildPackages.imx-mkimage}/bin/mkimage_imx8  -soc QX -rev B0 -append ahab-container.img -c -scfw mx8qx-mek-scfw-tcm.bin -ap u-boot-atf.bin a35 0x80000000 -out flash.bin
+    '';
+  };
+
+  ubootIMX8QM = buildUBoot {
+    version = "2022.04";
+    src = fetchGit {
+      url = "https://github.com/tiiuae/uboot-imx8.git";
+      ref = "lf_v2022.04-uefi";
+    };
+    patches = [
+      ./0001-imx8qm-uefi.patch
+    ];
+    BL31 = "${armTrustedFirmwareIMX8QM}/bl31.bin";
+    enableParallelBuilding = true;
+    defconfig = "imx8qm_mek_defconfig";
+    extraMeta.platforms = ["aarch64-linux"];
+    filesToInstall = [ "flash.bin" ];
+    preBuildPhases = [ "copyBinaries" ];
+    copyBinaries = ''
+      install -m 0644 ${armTrustedFirmwareIMX8QM}/bl31.bin ./bl31.bin
+      install -m 0644 ${imx-firmware}/mx8qmb0-ahab-container.img ./ahab-container.img
+      install -m 0644 ${imx-firmware}/mx8qm-mek-scfw-tcm.bin ./mx8qm-mek-scfw-tcm.bin
+    '';
+    postBuild = ''
+      ${buildPackages.imx-mkimage}/bin/mkimage_imx8 -commit > head.hash
+      cat u-boot.bin head.hash > u-boot-hash.bin
+      cp bl31.bin u-boot-atf.bin
+      dd if=u-boot-hash.bin of=u-boot-atf.bin bs=1K seek=128
+      ${buildPackages.imx-mkimage}/bin/mkimage_imx8 -soc QM -rev B0 -append ahab-container.img -c -scfw mx8qm-mek-scfw-tcm.bin -ap u-boot-atf.bin a35 0x80000000 -out flash.bin
     '';
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22826,6 +22826,7 @@ with pkgs;
     armTrustedFirmwareRK3399
     armTrustedFirmwareS905
     armTrustedFirmwareIMX8QXP
+    armTrustedFirmwareIMX8QM
     ;
 
   imx-firmware = callPackage ../misc/imx-firmware { };
@@ -23938,6 +23939,7 @@ with pkgs;
     ubootUtilite
     ubootWandboard
     ubootIMX8QXP
+    ubootIMX8QM
     ;
 
   # Upstream Barebox:


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
