### PR TITLE
Update linux-imx8 kernel to use the latest kernel from NXP

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-imx8.nix
+++ b/pkgs/os-specific/linux/kernel/linux-imx8.nix
@@ -3,33 +3,31 @@
 with lib;
 
 buildLinux (args // rec {
-  version = "5.10.109";
-  nxp_ref = "5.10-2.1.x-imx";
+  version = "5.15.32";
+  nxp_ref = "lf-5.15.y";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
 
   defconfig = "imx_v8_defconfig";
 
+  autoModules = false;
+
   extraConfig = ''
-    SECURE_KEYS n
-    FB n
-    FB_MXC n
-    FB_MXS n
-    MFD_MAX17135 n
-    REGULATOR_ARM_SCMI n
-    REGULATOR_PF1550_RPMSG n
-    MXC_PXP y
-    SND_IMX_SOC n
-    VIDEO_MXC_CAPTURE n
-    SENSORS_MAG3110 n
-    SENSORS_MAX17135 n
-    CRYPTO_TLS n
-    STAGING n
+    CRYPTO_TLS m
+    TLS y
+    MD_RAID0 m
+    MD_RAID1 m
+    MD_RAID10 m
+    MD_RAID456 m
+    DM_VERITY m
+    LOGO y
+    FRAMEBUFFER_CONSOLE_DEFERRED_TAKEOVER n
+    FB_EFI n
   '';
 
   src = fetchGit {
-    url = "https://github.com/Freescale/linux-fslc.git";
+    url = "https://source.codeaurora.org/external/imx/linux-imx";
     ref = nxp_ref;
   };
 } // (args.argsOverride or { }))


### PR DESCRIPTION
Signed-off-by: Yuri Nesterov <yuriy.nesterov@unikie.com>

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
