### PR TITLE
lib/systems/default.nix: add efiArch suffixes

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -135,6 +135,14 @@ rec {
           powerpc64le = "ppc64le";
         }.${final.parsed.cpu.name} or final.parsed.cpu.name;
 
+      # Name used by UEFI for architectures.
+      efiArch =
+        if final.isx86_32 then "ia32"
+        else if final.isx86_64 then "x64"
+        else if final.isAarch32 then "arm"
+        else if final.isAarch64 then "aa64"
+        else final.parsed.cpu.name;
+
       darwinArch = {
         armv7a  = "armv7";
         aarch64 = "arm64";

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -53,6 +53,13 @@ let
       image = "/boot/${config.system.boot.loader.kernelFile}";
       initrd = "/boot/initrd";
     };
+
+  targetArch =
+    if config.boot.loader.grub.forcei686 then
+      "ia32"
+    else
+      stdenv.hostPlatform.efiArch;
+
   in
     menuBuilderGrub2
     finalCfg
@@ -430,19 +437,6 @@ let
       # Verify the FAT partition.
       fsck.vfat -vn "$out"
     ''; # */
-
-  # Name used by UEFI for architectures.
-  targetArch =
-    if pkgs.stdenv.isi686 || config.boot.loader.grub.forcei686 then
-      "ia32"
-    else if pkgs.stdenv.isx86_64 then
-      "x64"
-    else if pkgs.stdenv.isAarch32 then
-      "arm"
-    else if pkgs.stdenv.isAarch64 then
-      "aa64"
-    else
-      throw "Unsupported architecture";
 
   # Syslinux (and isolinux) only supports x86-based architectures.
   canx86BiosBoot = pkgs.stdenv.hostPlatform.isx86;


### PR DESCRIPTION
These changes are already in Nixpkgs master and Nixpkgs-Spectrum rootfs branches. We decided to cherry-pick single commit instead of rebase because our nixpkgs-spectrum fork should be reworked to be as close as possible to upstream in near future.

Move already implemented functionality to the upper level so it could be used in a more generic way.

Signed-off-by: Ivan Nikolaenko <ivan.nikolaenko@unikie.com>
(cherry picked from commit f2518402378a2825ebb750337a1a7adedde1132a)