### PR TITLE
imx8: disable autosuspend on USB devices

### DIFF
--- a/pkgs/os-specific/linux/kernel/disable-autosuspend-usb.patch
+++ b/pkgs/os-specific/linux/kernel/disable-autosuspend-usb.patch
@@ -1,0 +1,10 @@
+diff --git a/arch/arm64/configs/imx_v8_defconfig b/arch/arm64/configs/imx_v8_defconfig
+index 2a8bc034cc18..00b544d85bb3 100644
+--- a/arch/arm64/configs/imx_v8_defconfig
++++ b/arch/arm64/configs/imx_v8_defconfig
+@@ -1048,3 +1048,4 @@ CONFIG_TRUSTED_KEYS=m
+ CONFIG_TRUSTED_KEYS_TPM=n
+ CONFIG_TRUSTED_KEYS_TEE=n
+ CONFIG_TRUSTED_KEYS_CAAM=y
++CONFIG_USB_AUTOSUSPEND_DELAY=-1
+\ No newline at end of file

--- a/pkgs/os-specific/linux/kernel/linux-imx8.nix
+++ b/pkgs/os-specific/linux/kernel/linux-imx8.nix
@@ -26,6 +26,11 @@ buildLinux (args // rec {
     FB_EFI n
   '';
 
+  kernelPatches = [ {
+    name = "Disable autosuspend USB devices";
+    patch = ./disable-autosuspend-usb.patch;
+  } ];
+
   src = fetchGit {
     url = "https://source.codeaurora.org/external/imx/linux-imx";
     ref = nxp_ref;


### PR DESCRIPTION
 Disable autosuspend on USB devices by imx_v8_defconfig
 kernel configuration. This to avoid disconnection
 problems with USB hubs and touch screens.

Signed-off-by: Juan Pablo Ruiz <juanpablo.ruiz@tii.ae>

###### Description of changes
Added a Linux kernel configuration patch to add the
CONFIG_USB_AUTOSUSPEND_DELAY=-1 in the 
arm64/configs/imx_v8_defconfig file. 

This disables the USB autosuspend avoiding automatic
disconnections on USB hubs attached to the imx8 boards. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
