### PR TITLE
 Fixed libusb1 build on aarm64; upgraded socat to 1.7.4.4; added nc-vsock tool

### DIFF
--- a/pkgs/development/libraries/libusb1/default.nix
+++ b/pkgs/development/libraries/libusb1/default.nix
@@ -4,6 +4,7 @@
 , autoreconfHook
 , pkg-config
 , enableUdev ? stdenv.isLinux && !stdenv.hostPlatform.isMusl
+, libudev-zero
 , udev
 , libobjc
 , IOKit
@@ -26,7 +27,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config autoreconfHook ];
   propagatedBuildInputs =
-    lib.optional enableUdev udev ++
+    lib.optional enableUdev libudev-zero ++
     lib.optionals stdenv.isDarwin [ libobjc IOKit Security ];
 
   dontDisableStatic = withStatic;
@@ -34,7 +35,7 @@ stdenv.mkDerivation rec {
   configureFlags = lib.optional (!enableUdev) "--disable-udev";
 
   preFixup = lib.optionalString enableUdev ''
-    sed 's,-ludev,-L${lib.getLib udev}/lib -ludev,' -i $out/lib/libusb-1.0.la
+    sed 's,-ludev,-L${lib.getLib libudev-zero}/lib -ludev,' -i $out/lib/libusb-1.0.la
   '';
 
   meta = with lib; {

--- a/pkgs/tools/networking/nc-vsock/default.nix
+++ b/pkgs/tools/networking/nc-vsock/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "nc-vsock";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "vadika";
+    repo = "nc-vsock";
+    sha256 = "sha256-NzL2dfdDaj9WgYQkavl382G4p5j/ewMS6Di4PdcoGIg=";
+    rev = "refs/tags/${version}";
+    fetchSubmodules = true;
+  };
+
+  # nativeBuildInputs = [ make ];
+
+  meta = with lib; {
+    description = "Netcat with VSOCKs";
+    homepage = "https://github.com/vadika/nc-vsock";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/networking/socat/default.nix
+++ b/pkgs/tools/networking/socat/default.nix
@@ -9,11 +9,11 @@
 
 stdenv.mkDerivation rec {
   pname = "socat";
-  version = "1.7.4.3";
+  version = "1.7.4.4";
 
   src = fetchurl {
     url = "http://www.dest-unreach.org/socat/download/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-1HMYEEQVB3Y1EZ3+5EvPtB3jSXN0qaABsa/24vCFgAc=";
+    sha256 = "sha256-+9Qr0vDlSjr20BvfFThThKuC28Dk8aXhU7PgvhtjgKw=";
   };
 
   postPatch = ''
@@ -23,14 +23,7 @@ stdenv.mkDerivation rec {
       --replace /sbin/ifconfig ifconfig
   '';
 
-  configureFlags = lib.optionals stdenv.hostPlatform.isMusl [
-    # musl doesn't have getprotobynumber_r
-    "sc_cv_getprotobynumber_r=2"
-  ];
-
-  buildInputs = [ openssl readline ];
-
-  hardeningEnable = [ "pie" ];
+  buildInputs = [ readline openssl ];
 
   checkInputs = [ which nettools ];
   doCheck = false; # fails a bunch, hangs

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9196,6 +9196,8 @@ with pkgs;
   netcat-gnu = callPackage ../tools/networking/netcat { };
 
   netcat-openbsd = callPackage ../tools/networking/netcat-openbsd { };
+  
+  nc-vsock = callPackage ../tools/networking/nc-vsock { };
 
   netdiscover = callPackage ../tools/networking/netdiscover { };
 
@@ -20341,7 +20343,7 @@ with pkgs;
     inherit (darwin) libobjc;
     inherit (darwin.apple_sdk.frameworks) IOKit Security;
     # TODO: remove once proper configuration is detected during build
-    enableUdev = false;
+    enableUdev = true;
     # TODO: remove once `udev` is `systemdMinimal` everywhere.
     udev = systemdMinimal;
   };


### PR DESCRIPTION
1. Fixed libusb1 build for musl/imx8/aarm64
2. Upgraded socat to 1.7.4.4, fixed runtime coredumps
3. Added nc-vsock tool to packages 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
