### PR TITLE
linux-imx8: Make the build pure

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-imx8.nix
+++ b/pkgs/os-specific/linux/kernel/linux-imx8.nix
@@ -1,10 +1,9 @@
-{ lib, stdenv, buildPackages, fetchurl, perl, buildLinux, modDirVersionArg ? null, ... } @ args:
+{ lib, stdenv, buildPackages, fetchgit, perl, buildLinux, modDirVersionArg ? null, ... } @ args:
 
 with lib;
 
 buildLinux (args // rec {
   version = "5.15.32";
-  nxp_ref = "lf-5.15.y";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
@@ -26,8 +25,9 @@ buildLinux (args // rec {
     FB_EFI n
   '';
 
-  src = fetchGit {
+  src = fetchgit {
     url = "https://source.codeaurora.org/external/imx/linux-imx";
-    ref = nxp_ref;
+    rev = "fa6c3168595c02bd9d5366fcc28c9e7304947a3d"; # lf-5.15.y
+    sha256 = "sha256-Z24CpePoP28tBumTGc8ZUm/5WghuhtO2jvPOKtNaYGA=";
   };
 } // (args.argsOverride or { }))


### PR DESCRIPTION
###### Description of changes

Minor changes:
- Add sha256 to make the build pure
- Also change from builtins.fetchGit to fetchgit, this causes kernel source code to be fetched during build time, and not evaluation time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
